### PR TITLE
support for /api/mysql-relay-log-index-file

### DIFF
--- a/go/cmd/orchestrator-agent/main.go
+++ b/go/cmd/orchestrator-agent/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	log.Debugf("Process token: %s", agent.ProcessToken.Hash)
 	if config.Config.TokenHintFile != "" {
+		log.Debugf("Writing token to TokenHintFile: %s", config.Config.TokenHintFile)
 		err := ioutil.WriteFile(config.Config.TokenHintFile, []byte(agent.ProcessToken.Hash), 0644)
 		log.Errore(err)
 	}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	ExecWithSudo                       bool              // If true, run os commands that need privileged access with sudo. Usually set when running agent with a non-privileged user
 	CustomCommands                     map[string]string // Anything in this list of options will be exposed as an API callable options
 	TokenHintFile                      string            // If defined, token will be stored in this file
+	TokenHttpHeader                    string            // If defined, name of HTTP header where token is presented (as alternative to query param)
 }
 
 var Config *Configuration = NewConfiguration()
@@ -101,6 +102,7 @@ func NewConfiguration() *Configuration {
 		ExecWithSudo:                       false,
 		CustomCommands:                     make(map[string]string),
 		TokenHintFile:                      "",
+		TokenHttpHeader:                    "",
 	}
 }
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -449,6 +449,21 @@ func (this *HttpAPI) Status(params martini.Params, r render.Render, req *http.Re
 	}
 }
 
+// RelayLogIndexFile returns mysql relay log index file, full path
+func (this *HttpAPI) RelayLogIndexFile(params martini.Params, r render.Render, req *http.Request) {
+	if err := validateToken(req.URL.Query().Get("token")); err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+
+	output, err := osagent.GetRelayLogIndexFileName()
+	if err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	r.JSON(200, output)
+}
+
 func (this *HttpAPI) RunCommand(params martini.Params, r render.Render, req *http.Request) {
 	var err error
 	if err = validateToken(req.URL.Query().Get("token")); err != nil {
@@ -502,6 +517,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/abort-seed/:seedId", this.AbortSeed)
 	m.Get("/api/seed-command-completed/:seedId", this.SeedCommandCompleted)
 	m.Get("/api/seed-command-succeeded/:seedId", this.SeedCommandSucceeded)
+	m.Get("/api/mysql-relay-log-index-file", this.RelayLogIndexFile)
 	m.Get("/api/custom-commands/:cmd", this.RunCommand)
 	m.Get(config.Config.StatusEndpoint, this.Status)
 }

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -61,6 +61,7 @@ func GetMySQLPort() (int64, error) {
 	return strconv.ParseInt(strings.TrimSpace(fmt.Sprintf("%s", output)), 10, 0)
 }
 
+// GetRelayLogIndexFileName attempts to find the relay log index file under the mysql datadir
 func GetRelayLogIndexFileName() (string, error) {
 	directory, err := GetMySQLDataDir()
 	if err != nil {
@@ -73,6 +74,27 @@ func GetRelayLogIndexFileName() (string, error) {
 	}
 
 	return strings.TrimSpace(fmt.Sprintf("%s", output)), err
+}
+
+// GetRelayLogFileNames attempts to find the active relay logs
+func GetRelayLogFileNames() (fileNames []string, err error) {
+	relayLogIndexFile, err := GetRelayLogIndexFileName()
+	if err != nil {
+		return fileNames, log.Errore(err)
+	}
+
+	contents, err := ioutil.ReadFile(relayLogIndexFile)
+	if err != nil {
+		return fileNames, log.Errore(err)
+	}
+
+	for _, fileName := range strings.Split(string(contents), "\n") {
+		if fileName != "" {
+			fileName = path.Join(path.Dir(relayLogIndexFile), fileName)
+			fileNames = append(fileNames, fileName)
+		}
+	}
+	return fileNames, nil
 }
 
 // Equals tests equality of this corrdinate and another one.


### PR DESCRIPTION
`/api/mysql-relay-log-index-file` heuristically returns the name of the relay log index file. 

There is a hidden assumption that this file lies under the MySQL `datadir`. This assumption may be lifted in the future.
