### PR TITLE
api for getting binary log contents

### DIFF
--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -97,6 +97,26 @@ func GetRelayLogFileNames() (fileNames []string, err error) {
 	return fileNames, nil
 }
 
+func MySQLBinlogContents(binlogFiles []string, startPosition int64, stopPosition int64) (string, error) {
+	if len(binlogFiles) == 0 {
+		return "", log.Errorf("No binlog files provided in MySQLBinlogContents")
+	}
+	cmd := `mysqlbinlog`
+	for _, binlogFile := range binlogFiles {
+		cmd = fmt.Sprintf("%s %s", cmd, binlogFile)
+	}
+	if startPosition != 0 {
+		cmd = fmt.Sprintf("%s --start-position=%d", cmd, startPosition)
+	}
+	if stopPosition != 0 {
+		cmd = fmt.Sprintf("%s --stop-position=%d", cmd, stopPosition)
+	}
+	cmd = fmt.Sprintf("%s | gzip | base64", cmd)
+
+	output, err := commandOutput(cmd)
+	return string(output), err
+}
+
 // Equals tests equality of this corrdinate and another one.
 func (this *LogicalVolume) IsSnapshotValid() bool {
 	if !this.IsSnapshot {


### PR DESCRIPTION
adding:
- `/api/mysql-binlog-contents`
- `/api/mysql-relaylog-contents-tail/:relaylog/:start`

both of which return the binary log contents of given files.
- `/api/mysql-binlog-contents` expect absolute file names, multiple files supported via `binlog=`. `start` and `stop` positions optional.
- `/api/mysql-relaylog-contents-tail/:relaylog/:start` expects one relay log file, either absolute path or not
