### PR TITLE
CI scripts

### DIFF
--- a/go/cmd/orchestrator-agent/main.go
+++ b/go/cmd/orchestrator-agent/main.go
@@ -29,6 +29,8 @@ import (
 	"github.com/outbrain/orchestrator-agent/go/config"
 )
 
+var AppVersion string
+
 func acceptSignal() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, os.Kill, syscall.SIGHUP)
@@ -57,7 +59,11 @@ func main() {
 		log.SetPrintStackTrace(*stack)
 	}
 
-	log.Info("starting")
+	if AppVersion == "" {
+		AppVersion = "local-build"
+	}
+
+	log.Info("starting orchestrator-agent %s", AppVersion)
 
 	if len(*configFile) > 0 {
 		config.ForceRead(*configFile)

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Make sure we have the version of Go we want to depend on, either from the
+# system or one we grab ourselves.
+. script/ensure-go-installed
+
+# Since we want to be able to build this outside of GOPATH, we set it
+# up so it points back to us and go is none the wiser
+
+set -x
+rm -rf .gopath
+mkdir -p .gopath/src/github.com/github
+ln -s "$PWD" .gopath/src/github.com/github/orchestrator-agent
+export GOPATH=$PWD/.gopath:$GOPATH

--- a/script/build
+++ b/script/build
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+. script/bootstrap
+
+mkdir -p bin
+bindir="$PWD"/bin
+scriptdir="$PWD"/script
+
+# We have a few binaries that we want to build, so let's put them into bin/
+
+version=$(git rev-parse HEAD)
+describe=$(git describe --tags --always --dirty)
+
+export GOPATH="$PWD/.gopath"
+cd .gopath/src/github.com/github/orchestrator-agent
+
+# We put the binaries directly into the bindir, because we have no need for shim wrappers
+go build -o "$bindir/orchestrator-agent" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/orchestrator-agent/main.go

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+. script/bootstrap
+
+echo "Verifying code is formatted via 'gofmt -s -w  go/'"
+gofmt -s -w  go/
+git diff --exit-code --quiet
+
+echo "Building"
+script/build
+
+cd .gopath/src/github.com/github/orchestrator-agent
+
+echo "Running unit tests"
+go test ./go/...

--- a/script/cibuild-gh-ost-build-deploy-tarball
+++ b/script/cibuild-gh-ost-build-deploy-tarball
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+script/cibuild
+
+# Get a fresh directory and make sure to delete it afterwards
+build_dir=tmp/build
+rm -rf $build_dir
+mkdir -p $build_dir
+trap "rm -rf $build_dir" EXIT
+
+commit_sha=$(git rev-parse HEAD)
+
+if [ $(uname -s) = "Darwin" ]; then
+    build_arch="$(uname -sr | tr -d ' ' | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+else
+    build_arch="$(lsb_release -sc | tr -d ' ' | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+fi
+
+tarball=$build_dir/${commit_sha}-${build_arch}.tar
+
+# Create the tarball
+tar cvf $tarball --mode="ugo=rx" bin/
+
+# Compress it and copy it to the directory for the CI to upload it
+gzip $tarball
+mkdir -p "$BUILD_ARTIFACT_DIR"/orchestrator-agent
+cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/orchestrator-agent/
+
+### HACK HACK HACK ###
+# blame @carlosmn
+# We don't have any jessie machines for building, but a pure-Go binary depends
+# on a version of libc and ld which are widely available, so we can copy the
+# tarball over with jessie in its name so we can deploy it on jessie machines.
+jessie_tarball_name=$(echo $(basename "${tarball}") | sed s/-precise-/-jessie-/)
+cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/orchestrator-agent/${jessie_tarball_name}.gz"

--- a/script/ensure-go-installed
+++ b/script/ensure-go-installed
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+GO_VERSION=go1.7
+
+GO_PKG_DARWIN=${GO_VERSION}.darwin-amd64.pkg
+GO_PKG_DARWIN_SHA=e7089843bc7148ffcc147759985b213604d22bb9fd19bd930b515aa981bf1b22
+
+GO_PKG_LINUX=${GO_VERSION}.linux-amd64.tar.gz
+GO_PKG_LINUX_SHA=702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95
+
+export ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd $ROOTDIR
+
+# If Go isn't installed globally, setup environment variables for local install.
+if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
+  GODIR="$ROOTDIR/.vendor/go17"
+
+  if [ $(uname -s) = "Darwin" ]; then
+    export GOROOT="$GODIR/usr/local/go"
+  else
+    export GOROOT="$GODIR/go"
+  fi
+
+  export PATH="$GOROOT/bin:$PATH"
+fi
+
+# Check if local install exists, and install otherwise.
+if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
+  [ -d "$GODIR" ] && rm -rf $GODIR
+  mkdir -p "$GODIR"
+  cd "$GODIR";
+
+  if [ $(uname -s) = "Darwin" ]; then
+    curl -L -O https://storage.googleapis.com/golang/$GO_PKG_DARWIN
+    shasum -a256 $GO_PKG_DARWIN | grep $GO_PKG_DARWIN_SHA
+    xar -xf $GO_PKG_DARWIN
+    cpio -i < com.googlecode.go.pkg/Payload
+  else
+    curl -L -O https://storage.googleapis.com/golang/$GO_PKG_LINUX
+    shasum -a256 $GO_PKG_LINUX | grep $GO_PKG_LINUX_SHA
+    tar xf $GO_PKG_LINUX
+  fi
+
+  # Prove we did something right
+  echo "$GO_VERSION installed in $GODIR: Go Binary: $(which go)"
+fi
+
+cd $ROOTDIR
+
+# Configure the new go to be the first go found
+export GOPATH=$ROOTDIR/.vendor

--- a/script/go
+++ b/script/go
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+. script/bootstrap
+
+mkdir -p bin
+bindir="$PWD"/bin
+
+cd .gopath/src/github.com/github/orchestrator-agent
+go "$@"


### PR DESCRIPTION
Adding CI scripts.

This will enable `orchestrator-agent` to have CI tests per push, with `master` being a protected branch.

This initial PR is initially simplified and we will iterate on the CI scripts later on. In particular, we will edit the build TAR archive to include the entire resources tree.

cc @github/database-infrastructure 