### PR TITLE
API for binlog binary contents

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -41,6 +41,7 @@ type Configuration struct {
 	ReceiveSeedDataCommand             string            // Accepts incoming data (e.g. tarball over netcat)
 	SendSeedDataCommand                string            // Sends date to remote host (e.g. tarball via netcat)
 	PostCopyCommand                    string            // command that is executed after seed is done and before MySQL starts
+	MySQLClientCommand                 string            // the `mysql` command, including ny neccesary credentials, to apply relay logs. This would be a fully-privileged account entry. Example: "mysql -uroot -p123456" or "mysql --defaults-file=/root/.my.cnf"
 	AgentsServer                       string            // HTTP address of the orchestrator agents server
 	AgentsServerPort                   string            // HTTP port of the orchestrator agents server
 	HTTPPort                           uint              // HTTP port on which this service listens
@@ -83,6 +84,7 @@ func NewConfiguration() *Configuration {
 		ReceiveSeedDataCommand:             "",
 		SendSeedDataCommand:                "",
 		PostCopyCommand:                    "",
+		MySQLClientCommand:                 "mysql",
 		AgentsServer:                       "",
 		AgentsServerPort:                   "",
 		HTTPPort:                           3002,

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -474,7 +474,7 @@ func (this *HttpAPI) RelayLogEndCoordinates(params martini.Params, r render.Rend
 	r.JSON(200, coordinates)
 }
 
-// BinlogContents returns contents of binary log entries
+// RelaylogContentsTail returns contents of relay logs, from given position to the very last entry
 func (this *HttpAPI) RelaylogContentsTail(params martini.Params, r render.Render, req *http.Request) {
 	if err := this.validateToken(r, req); err != nil {
 		return
@@ -501,7 +501,7 @@ func (this *HttpAPI) RelaylogContentsTail(params martini.Params, r render.Render
 		}
 	}
 
-	output, err := osagent.MySQLBinlogContents(parseRelaylogs, startPosition, 0)
+	output, err := osagent.MySQLBinlogBinaryContents(parseRelaylogs, startPosition, 0)
 	if err != nil {
 		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -509,8 +509,10 @@ func (this *HttpAPI) RelaylogContentsTail(params martini.Params, r render.Render
 	r.JSON(200, output)
 }
 
-// BinlogContents returns contents of binary log entries
-func (this *HttpAPI) BinlogContents(params martini.Params, r render.Render, req *http.Request) {
+// binlogContents returns contents of binary log entries
+func (this *HttpAPI) binlogContents(params martini.Params, r render.Render, req *http.Request,
+	contentsFunc func(binlogFiles []string, startPosition int64, stopPosition int64) (string, error),
+) {
 	if err := this.validateToken(r, req); err != nil {
 		return
 	}
@@ -536,6 +538,16 @@ func (this *HttpAPI) BinlogContents(params martini.Params, r render.Render, req 
 		return
 	}
 	r.JSON(200, output)
+}
+
+// BinlogContents returns contents of binary log entries
+func (this *HttpAPI) BinlogContents(params martini.Params, r render.Render, req *http.Request) {
+	this.binlogContents(params, r, req, osagent.MySQLBinlogContents)
+}
+
+// BinlogBinaryContents returns contents of binary log entries
+func (this *HttpAPI) BinlogBinaryContents(params martini.Params, r render.Render, req *http.Request) {
+	this.binlogContents(params, r, req, osagent.MySQLBinlogBinaryContents)
 }
 
 func (this *HttpAPI) RunCommand(params martini.Params, r render.Render, req *http.Request) {
@@ -593,6 +605,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/mysql-relay-log-files", this.RelayLogFiles)
 	m.Get("/api/mysql-relay-log-end-coordinates", this.RelayLogEndCoordinates)
 	m.Get("/api/mysql-binlog-contents", this.BinlogContents)
+	m.Get("/api/mysql-binlog-binary-contents", this.BinlogBinaryContents)
 	m.Get("/api/mysql-relaylog-contents-tail/:relaylog/:start", this.RelaylogContentsTail)
 	m.Get("/api/custom-commands/:cmd", this.RunCommand)
 	m.Get(config.Config.StatusEndpoint, this.Status)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -628,7 +628,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/mysql-binlog-contents", this.BinlogContents)
 	m.Get("/api/mysql-binlog-binary-contents", this.BinlogBinaryContents)
 	m.Get("/api/mysql-relaylog-contents-tail/:relaylog/:start", this.RelaylogContentsTail)
-	m.Get("/api/apply-relaylog-contents", this.ApplyRelaylogContents)
+	m.Post("/api/apply-relaylog-contents", this.ApplyRelaylogContents)
 	m.Get("/api/custom-commands/:cmd", this.RunCommand)
 	m.Get(config.Config.StatusEndpoint, this.Status)
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -552,13 +552,13 @@ func (this *HttpAPI) BinlogBinaryContents(params martini.Params, r render.Render
 }
 
 // ApplyRelaylogContents reads binlog contents from request's body and applies them locally
-func (this *HttpAPI) ApplyRelaylogContents(params martini.Params, r render.Render, req *http.Request, res *http.Response) {
+func (this *HttpAPI) ApplyRelaylogContents(params martini.Params, r render.Render, req *http.Request) {
 	if err := this.validateToken(r, req); err != nil {
 		return
 	}
-	defer res.Body.Close()
+	defer req.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -550,6 +551,26 @@ func (this *HttpAPI) BinlogBinaryContents(params martini.Params, r render.Render
 	this.binlogContents(params, r, req, osagent.MySQLBinlogBinaryContents)
 }
 
+// ApplyRelaylogContents reads binlog contents from request's body and applies them locally
+func (this *HttpAPI) ApplyRelaylogContents(params martini.Params, r render.Render, req *http.Request, res *http.Response) {
+	if err := this.validateToken(r, req); err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	err = osagent.ApplyRelaylogContents(body)
+	if err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	r.JSON(200, "OK")
+}
+
 func (this *HttpAPI) RunCommand(params martini.Params, r render.Render, req *http.Request) {
 	if err := this.validateToken(r, req); err != nil {
 		return
@@ -607,6 +628,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/mysql-binlog-contents", this.BinlogContents)
 	m.Get("/api/mysql-binlog-binary-contents", this.BinlogBinaryContents)
 	m.Get("/api/mysql-relaylog-contents-tail/:relaylog/:start", this.RelaylogContentsTail)
+	m.Get("/api/apply-relaylog-contents", this.ApplyRelaylogContents)
 	m.Get("/api/custom-commands/:cmd", this.RunCommand)
 	m.Get(config.Config.StatusEndpoint, this.Status)
 

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -152,7 +152,7 @@ func MySQLBinlogContentHeaderSize(binlogFile string) (int64, error) {
 	if content, err := commandOutput(sudoCmd(cmd)); err != nil {
 		return 0, err
 	} else {
-		return strconv.ParseInt(string(content), 10, 0)
+		return strconv.ParseInt(strings.TrimSpace(string(content)), 10, 0)
 	}
 }
 

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -210,7 +210,7 @@ func ApplyRelaylogContents(content []byte) error {
 		return log.Errore(err)
 	}
 
-	relaylogContentsFile, err := ioutil.TempFile("", "orchestrator-agent-apply-relaylog-")
+	relaylogContentsFile, err := ioutil.TempFile("", "orchestrator-agent-apply-relaylog-bin-")
 	if err != nil {
 		return log.Errore(err)
 	}
@@ -219,6 +219,14 @@ func ApplyRelaylogContents(content []byte) error {
 	if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 		return log.Errore(err)
 	}
+
+	if config.Config.MySQLClientCommand != "" {
+		cmd := fmt.Sprintf("mysqlbinlog %s | %s", relaylogContentsFile.Name(), config.Config.MySQLClientCommand)
+		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
+			return log.Errore(err)
+		}
+	}
+	log.Infof("Applied relay log contents from %s", relaylogContentsFile.Name())
 
 	return nil
 }

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -159,14 +159,14 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 		if i == 0 && startPosition != 0 {
 			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, startPosition)
 		}
-		cmd = fmt.Sprintf("%s >> %s", cmd, tmpFile)
+		cmd = fmt.Sprintf("%s >> %s", cmd, tmpFile.Name())
 		_, err = commandOutput(sudoCmd(cmd))
 		if err != nil {
 			return "", err
 		}
 	}
 
-	cmd := fmt.Sprintf("cat %s | gzip | base64", tmpFile)
+	cmd := fmt.Sprintf("cat %s | gzip | base64", tmpFile.Name())
 	output, err := commandOutput(cmd)
 	return string(output), err
 }

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -164,7 +164,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 			cmd = fmt.Sprintf("%s | head -c%d", cmd, stopPosition)
 		}
 		if i == 0 && startPosition != 0 {
-			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, startPosition)
+			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, (startPosition + 1))
 		}
 		cmd = fmt.Sprintf("%s >> %s", cmd, tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -169,7 +169,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 		if headerSize, err = MySQLBinlogContentHeaderSize(binlogFiles[0]); err != nil {
 			return "", log.Errore(err)
 		}
-		cmd := fmt.Sprintf("cat %s | head -c$%d >> %s", binlogFiles[0], headerSize, tmpFile.Name())
+		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], headerSize, tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -156,7 +156,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 		// We need both from the first log file.
 		// Typically, the format description ends at pos 120, but let's verify...
 
-		cmd := fmt.Sprintf("mysqlbinlog %s --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | awk '{print $2}' > %s", binlogFiles[0], binlogHeaderTmpFile.Name())
+		cmd := fmt.Sprintf("mysqlbinlog %s --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | head -1 | awk '{print $2}' > %s", binlogFiles[0], binlogHeaderTmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}
@@ -165,7 +165,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 	if err != nil {
 		return "", log.Errore(err)
 	}
-	{
+	if startPosition != 0 {
 		cmd := fmt.Sprintf("cat %s | head -c$(cat %s) >> %s", binlogFiles[0], binlogHeaderTmpFile.Name(), tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -142,31 +142,38 @@ func MySQLBinlogContents(binlogFiles []string, startPosition int64, stopPosition
 	return string(output), err
 }
 
-func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPosition int64) (string, error) {
+func MySQLBinlogContentHeaderSize(binlogFile string) (int64, error) {
+	tmpFile, err := ioutil.TempFile("", "orchestrator-agent-binlog-header-size-")
+	if err != nil {
+		return 0, log.Errore(err)
+	}
+	// magic header
+	// There are the first 4 bytes, and then there's also the first entry (the format-description).
+	// We need both from the first log file.
+	// Typically, the format description ends at pos 120, but let's verify...
+
+	cmd := fmt.Sprintf("mysqlbinlog %s --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | head -1 | awk '{print $2}' > %s", binlogFile, tmpFile.Name())
+	if content, err := commandOutput(sudoCmd(cmd)); err != nil {
+		return 0, err
+	} else {
+		return strconv.ParseInt(string(content), 10, 0)
+	}
+}
+
+func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPosition int64) (result string, err error) {
 	if len(binlogFiles) == 0 {
 		return "", log.Errorf("No binlog files provided in MySQLBinlogContents")
-	}
-	binlogHeaderTmpFile, err := ioutil.TempFile("", "orchestrator-agent-binlog-header-size-")
-	if err != nil {
-		return "", log.Errore(err)
-	}
-	{
-		// magic header
-		// There are the first 4 bytes, and then there's also the first entry (the format-description).
-		// We need both from the first log file.
-		// Typically, the format description ends at pos 120, but let's verify...
-
-		cmd := fmt.Sprintf("mysqlbinlog %s --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | head -1 | awk '{print $2}' > %s", binlogFiles[0], binlogHeaderTmpFile.Name())
-		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
-			return "", err
-		}
 	}
 	tmpFile, err := ioutil.TempFile("", "orchestrator-agent-binlog-contents-")
 	if err != nil {
 		return "", log.Errore(err)
 	}
+	var headerSize int64
 	if startPosition != 0 {
-		cmd := fmt.Sprintf("cat %s | head -c$(cat %s) >> %s", binlogFiles[0], binlogHeaderTmpFile.Name(), tmpFile.Name())
+		if headerSize, err = MySQLBinlogContentHeaderSize(binlogFiles[0]); err != nil {
+			return "", log.Errore(err)
+		}
+		cmd := fmt.Sprintf("cat %s | head -c$%d >> %s", binlogFiles[0], headerSize, tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}
@@ -179,6 +186,13 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 		}
 		if i == 0 && startPosition != 0 {
 			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, (startPosition + 1))
+		}
+		if i > 0 {
+			// At any case, we drop out binlog header (magic + format_description) for next relay logs
+			if headerSize, err = MySQLBinlogContentHeaderSize(binlogFile); err != nil {
+				return "", log.Errore(err)
+			}
+			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, (headerSize + 1))
 		}
 		cmd = fmt.Sprintf("%s >> %s", cmd, tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -143,16 +143,12 @@ func MySQLBinlogContents(binlogFiles []string, startPosition int64, stopPosition
 }
 
 func MySQLBinlogContentHeaderSize(binlogFile string) (int64, error) {
-	tmpFile, err := ioutil.TempFile("", "orchestrator-agent-binlog-header-size-")
-	if err != nil {
-		return 0, log.Errore(err)
-	}
 	// magic header
 	// There are the first 4 bytes, and then there's also the first entry (the format-description).
 	// We need both from the first log file.
 	// Typically, the format description ends at pos 120, but let's verify...
 
-	cmd := fmt.Sprintf("mysqlbinlog %s --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | head -1 | awk '{print $2}' > %s", binlogFile, tmpFile.Name())
+	cmd := fmt.Sprintf("mysqlbinlog %s --start-position=4 | head | egrep -o 'end_log_pos [^ ]+' | head -1 | awk '{print $2}'", binlogFile)
 	if content, err := commandOutput(sudoCmd(cmd)); err != nil {
 		return 0, err
 	} else {

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -201,6 +201,14 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 	return string(output), err
 }
 
+func ApplyRelaylogContents(content []byte) error {
+	tmpFile, err := ioutil.TempFile("", "orchestrator-agent-apply-relaylog-contents-")
+	if err != nil {
+		return log.Errore(err)
+	}
+	return ioutil.WriteFile(tmpFile.Name(), content, 0644)
+}
+
 // Equals tests equality of this corrdinate and another one.
 func (this *LogicalVolume) IsSnapshotValid() bool {
 	if !this.IsSnapshot {

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -150,6 +150,13 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 	if err != nil {
 		return "", log.Errore(err)
 	}
+	{
+		// magic header
+		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], 4, tmpFile.Name())
+		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
+			return "", err
+		}
+	}
 	for i, binlogFile := range binlogFiles {
 		cmd := fmt.Sprintf("cat %s", binlogFile)
 
@@ -160,8 +167,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, startPosition)
 		}
 		cmd = fmt.Sprintf("%s >> %s", cmd, tmpFile.Name())
-		_, err = commandOutput(sudoCmd(cmd))
-		if err != nil {
+		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}
 	}

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -152,7 +152,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 	}
 	{
 		// magic header
-		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], 4, tmpFile.Name())
+		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], 120, tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -152,7 +152,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 	}
 	{
 		// magic header
-		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], (120 + 1), tmpFile.Name())
+		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], 120, tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -161,7 +161,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 		cmd := fmt.Sprintf("cat %s", binlogFile)
 
 		if i == len(binlogFiles)-1 && stopPosition != 0 {
-			cmd = fmt.Sprintf("%s | head -c%d", cmd, stopPosition)
+			cmd = fmt.Sprintf("%s | head -c %d", cmd, stopPosition)
 		}
 		if i == 0 && startPosition != 0 {
 			cmd = fmt.Sprintf("%s | tail -c+%d", cmd, (startPosition + 1))

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -152,7 +152,7 @@ func MySQLBinlogBinaryContents(binlogFiles []string, startPosition int64, stopPo
 	}
 	{
 		// magic header
-		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], 120, tmpFile.Name())
+		cmd := fmt.Sprintf("cat %s | head -c%d >> %s", binlogFiles[0], (120 + 1), tmpFile.Name())
 		if _, err := commandOutput(sudoCmd(cmd)); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
`osagent` and API to provide `/api/mysql-relaylog-contents-tail/:relaylog/:start` as encoded binary contents of the relay logs. That is, the relay logs are not extracted via `mysqlbinlog`. Instead, the very binary contents of the relay logs are sliced (prepended with magic header and with initial format description)