### PR TITLE
Move references from outbrain/orchestrator to github/orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ orchestrator-agent
 
 MySQL topology agent (daemon)
 
-**orchestrator-agent** is a sub-project of [orchestrator](https://github.com/outbrain/orchestrator).
+**orchestrator-agent** is a sub-project of [orchestrator](https://github.com/github/orchestrator).
 It is a service that runs on MySQL hosts and communicates with *orchestrator*.
 
 **orchestrator-agent** is capable of proving operating system, file system and LVM information to *orchestrator*, as well

--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -23,10 +23,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/github/orchestrator-agent/go/config"
+	"github.com/github/orchestrator-agent/go/osagent"
+	"github.com/github/orchestrator-agent/go/ssl"
 	"github.com/outbrain/golib/log"
-	"github.com/outbrain/orchestrator-agent/go/config"
-	"github.com/outbrain/orchestrator-agent/go/osagent"
-	"github.com/outbrain/orchestrator-agent/go/ssl"
 )
 
 var httpTimeout = time.Duration(time.Duration(config.Config.HttpTimeoutSeconds) * time.Second)

--- a/go/app/http.go
+++ b/go/app/http.go
@@ -28,11 +28,11 @@ import (
 
 	nethttp "net/http"
 
+	"github.com/github/orchestrator-agent/go/agent"
+	"github.com/github/orchestrator-agent/go/config"
+	"github.com/github/orchestrator-agent/go/http"
+	"github.com/github/orchestrator-agent/go/ssl"
 	"github.com/outbrain/golib/log"
-	"github.com/outbrain/orchestrator-agent/go/agent"
-	"github.com/outbrain/orchestrator-agent/go/config"
-	"github.com/outbrain/orchestrator-agent/go/http"
-	"github.com/outbrain/orchestrator-agent/go/ssl"
 )
 
 // Http starts serving HTTP (api/web) requests

--- a/go/cmd/orchestrator-agent/main.go
+++ b/go/cmd/orchestrator-agent/main.go
@@ -23,10 +23,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/github/orchestrator-agent/go/agent"
+	"github.com/github/orchestrator-agent/go/app"
+	"github.com/github/orchestrator-agent/go/config"
 	"github.com/outbrain/golib/log"
-	"github.com/outbrain/orchestrator-agent/go/agent"
-	"github.com/outbrain/orchestrator-agent/go/app"
-	"github.com/outbrain/orchestrator-agent/go/config"
 )
 
 var AppVersion string

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -28,11 +28,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/github/orchestrator-agent/go/agent"
+	"github.com/github/orchestrator-agent/go/config"
+	"github.com/github/orchestrator-agent/go/osagent"
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/render"
-	"github.com/outbrain/orchestrator-agent/go/agent"
-	"github.com/outbrain/orchestrator-agent/go/config"
-	"github.com/outbrain/orchestrator-agent/go/osagent"
 )
 
 type HttpAPI struct{}

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -27,9 +27,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/github/orchestrator-agent/go/config"
+	"github.com/github/orchestrator-agent/go/inst"
 	"github.com/outbrain/golib/log"
-	"github.com/outbrain/orchestrator-agent/go/config"
-	"github.com/outbrain/orchestrator-agent/go/inst"
 )
 
 const (

--- a/go/ssl/ssl.go
+++ b/go/ssl/ssl.go
@@ -8,9 +8,9 @@ import (
 	nethttp "net/http"
 	"strings"
 
+	"github.com/github/orchestrator-agent/go/config"
 	"github.com/go-martini/martini"
 	"github.com/outbrain/golib/log"
-	"github.com/outbrain/orchestrator-agent/go/config"
 )
 
 var cipherSuites = []uint16{

--- a/go/ssl/ssl_test.go
+++ b/go/ssl/ssl_test.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/outbrain/orchestrator-agent/go/config"
-	"github.com/outbrain/orchestrator-agent/go/ssl"
+	"github.com/github/orchestrator-agent/go/config"
+	"github.com/github/orchestrator-agent/go/ssl"
 )
 
 func TestHasString(t *testing.T) {

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -11,6 +11,6 @@ set -e
 
 set -x
 rm -rf .gopath
-mkdir -p .gopath/src/github.com/outbrain
-ln -s "$PWD" .gopath/src/github.com/outbrain/orchestrator-agent
+mkdir -p .gopath/src/github.com/github
+ln -s "$PWD" .gopath/src/github.com/github/orchestrator-agent
 export GOPATH=$PWD/.gopath:$GOPATH

--- a/script/build
+++ b/script/build
@@ -14,7 +14,7 @@ version=$(git rev-parse HEAD)
 describe=$(git describe --tags --always --dirty)
 
 export GOPATH="$PWD/.gopath"
-cd .gopath/src/github.com/outbrain/orchestrator-agent
+cd .gopath/src/github.com/github/orchestrator-agent
 
 # We put the binaries directly into the bindir, because we have no need for shim wrappers
 go build -o "$bindir/orchestrator-agent" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/orchestrator-agent/main.go

--- a/script/cibuild
+++ b/script/cibuild
@@ -11,7 +11,7 @@ git diff --exit-code --quiet
 echo "Building"
 script/build
 
-cd .gopath/src/github.com/outbrain/orchestrator-agent
+cd .gopath/src/github.com/github/orchestrator-agent
 
 echo "Running unit tests"
 go test ./go/...

--- a/script/go
+++ b/script/go
@@ -7,5 +7,5 @@ set -e
 mkdir -p bin
 bindir="$PWD"/bin
 
-cd .gopath/src/github.com/outbrain/orchestrator-agent
+cd .gopath/src/github.com/github/orchestrator-agent
 go "$@"


### PR DESCRIPTION
This at least partially fixes the build.sh script. The shell out to `fpm` to build the cli packages fail, I'll be submitting a second PR to address that.