### PR TITLE
Remove cli build steps, fix dpkg name when building on Darwin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,7 @@ function package() {
 
       echo "Creating Distro full packages"
       fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t rpm -n orchestrator-agent -C $builddir/orchestrator-agent --prefix=/ .
-      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t deb -a "$target-$arch" -n orchestrator-agent -C $builddir/orchestrator-agent --prefix=/ --deb-no-default-config-files .
+      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t deb -a "$arch" -n orchestrator-agent -C $builddir/orchestrator-agent --prefix=/ --deb-no-default-config-files .
 
       cd $TOPDIR
       ;;

--- a/build.sh
+++ b/build.sh
@@ -86,11 +86,11 @@ function oinstall() {
 }
 
 function package() {
-  local target builddir prefix packages
+  local target builddir prefix packages arch
   target="$1"
   arch="$2"
-  prefix="$3"
   builddir="$3"
+  prefix="$4"
 
   cd $TOPDIR
 

--- a/build.sh
+++ b/build.sh
@@ -88,8 +88,9 @@ function oinstall() {
 function package() {
   local target builddir prefix packages
   target="$1"
-  builddir="$2"
+  arch="$2"
   prefix="$3"
+  builddir="$3"
 
   cd $TOPDIR
 
@@ -102,19 +103,14 @@ function package() {
 
       echo "Creating Distro full packages"
       fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t rpm -n orchestrator-agent -C $builddir/orchestrator-agent --prefix=/ .
-      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t deb -n orchestrator-agent -C $builddir/orchestrator-agent --prefix=/ --deb-no-default-config-files .
+      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t deb -a "$target-$arch" -n orchestrator-agent -C $builddir/orchestrator-agent --prefix=/ --deb-no-default-config-files .
 
       cd $TOPDIR
-      # rpm packaging -- executable only
-      echo "Creating Distro cli packages"
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -t rpm -n orchestrator-agent-cli -C $builddir/orchestrator-agent-cli --prefix=/ .
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -t deb -n orchestrator-agent-cli -C $builddir/orchestrator-agent-cli --prefix=/ --deb-no-default-config-files .
       ;;
     'darwin')
       echo "Creating Darwin full Package"
       tar -C $builddir/orchestrator-agent -czf $TOPDIR/orchestrator-agent-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
-      echo "Creating Darwin cli Package"
-      tar -C $builddir/orchestrator-agent-cli -czf $TOPDIR/orchestrator-agent-cli-"${RELEASE_VERSION}"-$target-$arch.tar.gz ./
+
       ;;
   esac
 
@@ -156,7 +152,7 @@ function main() {
   build "$target" "$arch" "$builddir" "$prefix"
   [[ $? == 0 ]] || return 1
   if [[ $build_only -eq 0 ]]; then
-    package "$target" "$builddir" "$prefix"
+    package "$target" "$arch" "$builddir" "$prefix"
   fi
 }
 


### PR DESCRIPTION
As far as I can tell, the CLI stuff doesn't yet exist in master for orchestrator-agent, so I've removed that from build.sh.  My go-fu isn't that great, so if I'm just overlooking where it lives, let me know and I'll update that.

Also fix build.sh so fpm pukes out the appopriate package name for the Debian build when building Linux packages on a Darwin host, `orchestrator-agent_1.2.1_amd64.deb` instead of `orchestrator-agent_1.2.1_darwin-amd64.deb`; as well as set the arch properly in the package metadata (needs to be `amd64` and not `darwin-amd64`)