### PR TITLE
Add configuration option for location of my.cnf file

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -32,6 +32,7 @@ type Configuration struct {
 	AvailableLocalSnapshotHostsCommand string            // Command which returns list of hosts (one host per line) with available snapshots in local datacenter
 	AvailableSnapshotHostsCommand      string            // Command which returns list of hosts (one host per line) with available snapshots in any datacenter
 	SnapshotVolumesFilter              string            // text pattern filtering agent logical volumes that are valid snapshots
+	MySQLConfigFileLocation            string            // Path to my.cnf (default: /etc/my.cnf)
 	MySQLDatadirCommand                string            // command expected to present with @@datadir
 	MySQLPortCommand                   string            // command expected to present with @@port
 	MySQLDeleteDatadirContentCommand   string            // command which deletes all content from MySQL datadir (does not remvoe directory itself)
@@ -75,6 +76,7 @@ func NewConfiguration() *Configuration {
 		AvailableLocalSnapshotHostsCommand: "",
 		AvailableSnapshotHostsCommand:      "",
 		SnapshotVolumesFilter:              "",
+		MySQLConfigFileLocation:            "/etc/my.cnf",
 		MySQLDatadirCommand:                "",
 		MySQLPortCommand:                   "",
 		MySQLDeleteDatadirContentCommand:   "",

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -559,10 +559,9 @@ func AvailableSnapshots(requireLocal bool) ([]string, error) {
 }
 
 func MySQLErrorLogTail() ([]string, error) {
-	// XXX: MARKER
 	mycnf := config.Config.MySQLConfigFileLocation
 
-	command := fnt.Sprintf(`tail -n 20 $(egrep "log[-_]error" %s | cut -d "=" -f 2)`, mycnf)
+	command := fmt.Sprintf(`tail -n 20 $(egrep "log[-_]error" %s | cut -d "=" -f 2)`, mycnf)
 
 	output, err := commandOutput(sudoCmd(command))
 	tail, err := outputLines(output, err)

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -559,7 +559,12 @@ func AvailableSnapshots(requireLocal bool) ([]string, error) {
 }
 
 func MySQLErrorLogTail() ([]string, error) {
-	output, err := commandOutput(sudoCmd(`tail -n 20 $(egrep "log[-_]error" /etc/my.cnf | cut -d "=" -f 2)`))
+	// XXX: MARKER
+	mycnf := config.Config.MySQLConfigFileLocation
+
+	command := fnt.Sprintf(`tail -n 20 $(egrep "log[-_]error" %s | cut -d "=" -f 2)`, mycnf)
+
+	output, err := commandOutput(sudoCmd(command))
 	tail, err := outputLines(output, err)
 	return tail, err
 }


### PR DESCRIPTION
Percona's Ubuntu packages drop `my.cnf` at `/etc/mysql/my.cnf`. 

There's only one reference to that file directly in `orchestrator-agent`, but this avoids having to create a symbolic link to the correct location by exposing a configuration knob. 